### PR TITLE
更新readme文件

### DIFF
--- a/packages/picker/README.md
+++ b/packages/picker/README.md
@@ -4,11 +4,12 @@ vue-picker is a multi-slot picker based on vue.js.
 # Install
 
 ```Bash
+npm install mint-picker --save
 npm install vue-picker --save
 ```
 
 ```JavaScript
-require ('mint-picker/lib/index.css');
+require ('mint-picker/lib/style.css');
 
 // ES6 mudule
 import Picker from 'mint-picker';


### PR DESCRIPTION
使用`vue-picker`组件过程中：
1. 增加`vue-picker`的依赖包`mint-picker`
2. 发现不存在`mint-picker/lib/index.css`，正确路径为`mint-picker/lib/style.css`