### PR TITLE
add visibleItemCount property for datetime-picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "babel-core": "^6.14.0",
     "babel-loader": "^6.2.5",
     "babel-preset-es2015": "^6.14.0",
+    "babel-preset-stage-2": "^6.17.0",
     "cooking": "^1.0.1",
     "cooking-lint": "^0.1.2",
     "cooking-saladcss": "^0.4.0",

--- a/packages/datetime-picker/src/datetime-picker.vue
+++ b/packages/datetime-picker/src/datetime-picker.vue
@@ -1,46 +1,46 @@
 <template>
-	<mt-popup :visible.sync="visible" position="bottom" class="mint-datetime">
-		<mt-picker 
+  <mt-popup :visible.sync="visible" position="bottom" class="mint-datetime">
+    <mt-picker 
     :slots="dateSlots" 
     @change="onChange" 
     :visible-item-count="visibleItemCount" 
     class="mint-datetime-picker" 
     v-ref:picker
-			show-toolbar>
-			<span class="mint-datetime-action mint-datetime-cancel" @click="visible = false">{{ cancelText }}</span>
-			<span class="mint-datetime-action mint-datetime-confirm" @click="confirm">{{ confirmText }}</span>
-		</mt-picker>
-	</mt-popup>
+    show-toolbar>
+      <span class="mint-datetime-action mint-datetime-cancel" @click="visible = false">{{ cancelText }}</span>
+      <span class="mint-datetime-action mint-datetime-confirm" @click="confirm">{{ confirmText }}</span>
+    </mt-picker>
+  </mt-popup>
 </template>
 
 <style lang="css">
-	@import "../../../src/style/var.css";
-	@component-namespace mint {
-		@component datetime {
-			width: 100%;
-			.picker-slot-wrapper,
-			.picker-item {
-				backface-visibility: hidden;
-			}
-			.picker-toolbar {
-				border-bottom: solid 1px #eaeaea;
-			}
-			@descendent action {
-				display: inline-block;
-				width: 50%;
-				text-align: center;
-				line-height: 40px;
-				font-size: 16px;
-				color: $color-blue;
-			}
-			@descendent cancel {
-				float: left;
-			}
-			@descendent confirm {
-				float: right;
-			}
-		}
-	}
+  @import "../../../src/style/var.css";
+  @component-namespace mint {
+    @component datetime {
+      width: 100%;
+      .picker-slot-wrapper,
+      .picker-item {
+        backface-visibility: hidden;
+      }
+      .picker-toolbar {
+        border-bottom: solid 1px #eaeaea;
+      }
+      @descendent action {
+        display: inline-block;
+        width: 50%;
+        text-align: center;
+        line-height: 40px;
+        font-size: 16px;
+        color: $color-blue;
+      }
+      @descendent cancel {
+        float: left;
+      }
+      @descendent confirm {
+        float: right;
+      }
+    }
+  }
 </style>
 
 <script type="text/babel">

--- a/packages/datetime-picker/src/datetime-picker.vue
+++ b/packages/datetime-picker/src/datetime-picker.vue
@@ -1,10 +1,10 @@
 <template>
   <mt-popup :visible.sync="visible" position="bottom" class="mint-datetime">
-    <mt-picker 
-    :slots="dateSlots" 
-    @change="onChange" 
-    :visible-item-count="visibleItemCount" 
-    class="mint-datetime-picker" 
+    <mt-picker
+    :slots="dateSlots"
+    @change="onChange"
+    :visible-item-count="visibleItemCount"
+    class="mint-datetime-picker"
     v-ref:picker
     show-toolbar>
       <span class="mint-datetime-action mint-datetime-cancel" @click="visible = false">{{ cancelText }}</span>

--- a/packages/datetime-picker/src/datetime-picker.vue
+++ b/packages/datetime-picker/src/datetime-picker.vue
@@ -1,51 +1,46 @@
 <template>
-  <mt-popup :visible.sync="visible" position="bottom" class="mint-datetime">
-    <mt-picker
-      :slots="dateSlots"
-      @change="onChange"
-      :visible-item-count="7"
-      class="mint-datetime-picker"
-      v-ref:picker
-      show-toolbar>
-      <span class="mint-datetime-action mint-datetime-cancel" @click="visible = false">{{ cancelText }}</span>
-      <span class="mint-datetime-action mint-datetime-confirm" @click="confirm">{{ confirmText }}</span>
-    </mt-picker>
-  </mt-popup>
+	<mt-popup :visible.sync="visible" position="bottom" class="mint-datetime">
+		<mt-picker 
+    :slots="dateSlots" 
+    @change="onChange" 
+    :visible-item-count="visibleItemCount" 
+    class="mint-datetime-picker" 
+    v-ref:picker
+			show-toolbar>
+			<span class="mint-datetime-action mint-datetime-cancel" @click="visible = false">{{ cancelText }}</span>
+			<span class="mint-datetime-action mint-datetime-confirm" @click="confirm">{{ confirmText }}</span>
+		</mt-picker>
+	</mt-popup>
 </template>
 
 <style lang="css">
-  @import "../../../src/style/var.css";
-
-  @component-namespace mint {
-    @component datetime {
-      width: 100%;
-
-      .picker-slot-wrapper, .picker-item {
-        backface-visibility: hidden;
-      }
-
-      .picker-toolbar {
-        border-bottom: solid 1px #eaeaea;
-      }
-
-      @descendent action {
-        display: inline-block;
-        width: 50%;
-        text-align: center;
-        line-height: 40px;
-        font-size: 16px;
-        color: $color-blue;
-      }
-
-      @descendent cancel {
-        float: left;
-      }
-
-      @descendent confirm {
-        float: right;
-      }
-    }
-  }
+	@import "../../../src/style/var.css";
+	@component-namespace mint {
+		@component datetime {
+			width: 100%;
+			.picker-slot-wrapper,
+			.picker-item {
+				backface-visibility: hidden;
+			}
+			.picker-toolbar {
+				border-bottom: solid 1px #eaeaea;
+			}
+			@descendent action {
+				display: inline-block;
+				width: 50%;
+				text-align: center;
+				line-height: 40px;
+				font-size: 16px;
+				color: $color-blue;
+			}
+			@descendent cancel {
+				float: left;
+			}
+			@descendent confirm {
+				float: right;
+			}
+		}
+	}
 </style>
 
 <script type="text/babel">
@@ -113,6 +108,10 @@
       minuteFormat: {
         type: String,
         default: '{value}'
+      },
+      visibleItemCount: {
+        type: Number,
+        default: 5
       },
       value: null
     },


### PR DESCRIPTION
datetime-picker can not set visible-item-count, but I need this feature.

vue-msgbox need "babel-preset-stage-2", so I add it in package.json
