### PR TITLE
选择器，例如城市选择器，希望得到的不仅仅是城市名，可能还需要城市编码

### DIFF
--- a/packages/picker/src/picker-slot.vue
+++ b/packages/picker/src/picker-slot.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="picker-slot" :class="classNames" :style="flexStyle">
     <div v-if="!divider" ref="wrapper" class="picker-slot-wrapper" :class="{ dragging: dragging }" :style="{ height: contentHeight + 'px' }">
-      <div class="picker-item" v-for="itemValue in mutatingValues" :class="{ 'picker-selected': itemValue === currentValue }">{{ itemValue }}</div>
+      <div class="picker-item" v-for="itemValue in mutatingValues" :class="{ 'picker-selected': itemValue === currentValue }">{{ typeof itemValue === 'object'?itemValue.name:itemValue }}</div>
     </div>
     <div v-if="divider">{{ content }}</div>
   </div>


### PR DESCRIPTION

选择器，例如城市选择器，希望得到的不仅仅是城市名，可能还需要城市编码
为slots扩展为支持对象数组，（扔兼容之前的字符串数组）这样不仅可以取到名称值，也可以取到对应编码值。
如下面使用方法：
`typeSlots: [{
                flex: 1,
                values: [{id:'2',name:'婚礼策划'},
                  {id:'6', name:'婚纱摄影'},
                ],
                className: 'slot1'
              }],`

在回调中取得名称与编码
`onTypeChange(picker, values){
            this.type = values[0].name
            this.type_code = values[0].id
          },`
