### PR TITLE
Picker : add `itemHeight` props

### DIFF
--- a/packages/picker/README.md
+++ b/packages/picker/README.md
@@ -75,6 +75,7 @@ Picker Options:
 | showToolbar | Boolean(default: false) show a toolbar on top of picker when showToolbar is true. |
 | visibleItemCount | Number(default: 5) visible item count of each slot. |
 | rotateEffect | Boolean(default: false) use rotate effect on picker item when rotateEffect is true. |
+| itemHeight | Number(default: 36) height of each slot. |
 
 Picker Methods:
 

--- a/packages/picker/src/picker-slot.vue
+++ b/packages/picker/src/picker-slot.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="picker-slot" :class="classNames" :style="flexStyle">
     <div v-if="!divider" ref="wrapper" class="picker-slot-wrapper" :class="{ dragging: dragging }" :style="{ height: contentHeight + 'px' }">
-      <div class="picker-item" v-for="itemValue in mutatingValues" :class="{ 'picker-selected': itemValue === currentValue }">
+      <div class="picker-item" v-for="itemValue in mutatingValues" :class="{ 'picker-selected': itemValue === currentValue }" :style="{ height: itemHeight + 'px', lineHeight: itemHeight + 'px' }">
         {{ typeof itemValue === 'object' && itemValue[valueKey] ? itemValue[valueKey] : itemValue }}
       </div>
     </div>
@@ -152,7 +152,11 @@
       },
       flex: {},
       className: {},
-      content: {}
+      content: {},
+      itemHeight: {
+        type: Number,
+        default: ITEM_HEIGHT
+      }
     },
 
     data() {
@@ -197,7 +201,7 @@
         return resultArray.join(' ');
       },
       contentHeight() {
-        return ITEM_HEIGHT * this.visibleItemCount;
+        return this.itemHeight * this.visibleItemCount;
       },
       valueIndex() {
         return this.mutatingValues.indexOf(this.currentValue);
@@ -205,8 +209,9 @@
       dragRange() {
         var values = this.mutatingValues;
         var visibleItemCount = this.visibleItemCount;
+        var itemHeight = this.itemHeight;
 
-        return [ -ITEM_HEIGHT * (values.length - Math.ceil(visibleItemCount / 2)), ITEM_HEIGHT * Math.floor(visibleItemCount / 2) ];
+        return [ -itemHeight * (values.length - Math.ceil(visibleItemCount / 2)), itemHeight * Math.floor(visibleItemCount / 2) ];
       }
     },
 
@@ -215,15 +220,17 @@
         var values = this.mutatingValues;
         var valueIndex = values.indexOf(value);
         var offset = Math.floor(this.visibleItemCount / 2);
+        var itemHeight = this.itemHeight;
 
         if (valueIndex !== -1) {
-          return (valueIndex - offset) * -ITEM_HEIGHT;
+          return (valueIndex - offset) * -itemHeight;
         }
       },
 
       translate2Value(translate) {
-        translate = Math.round(translate / ITEM_HEIGHT) * ITEM_HEIGHT;
-        var index = -(translate - Math.floor(this.visibleItemCount / 2) * ITEM_HEIGHT) / ITEM_HEIGHT;
+        var itemHeight = this.itemHeight;
+        translate = Math.round(translate / itemHeight) * itemHeight;
+        var index = -(translate - Math.floor(this.visibleItemCount / 2) * itemHeight) / itemHeight;
 
         return this.mutatingValues[index];
       },
@@ -245,10 +252,10 @@
         var angleUnit = VISIBLE_ITEMS_ANGLE_MAP[this.visibleItemCount] || -20;
 
         [].forEach.call(pickerItems, (item, index) => {
-          var itemOffsetTop = index * ITEM_HEIGHT;
+          var itemOffsetTop = index * this.itemHeight;
           var translateOffset = dragRange[1] - currentTranslate;
           var itemOffset = itemOffsetTop - translateOffset;
-          var percentage = itemOffset / ITEM_HEIGHT;
+          var percentage = itemOffset / this.itemHeight;
 
           var angle = angleUnit * percentage;
           if (angle > 180) angle = 180;
@@ -334,10 +341,11 @@
 
             this.$nextTick(() => {
               var translate;
+              var itemHeight = this.itemHeight;
               if (momentumTranslate) {
-                translate = Math.round(momentumTranslate / ITEM_HEIGHT) * ITEM_HEIGHT;
+                translate = Math.round(momentumTranslate / itemHeight) * itemHeight;
               } else {
-                translate = Math.round(currentTranslate / ITEM_HEIGHT) * ITEM_HEIGHT;
+                translate = Math.round(currentTranslate / itemHeight) * itemHeight;
               }
 
               translate = Math.max(Math.min(translate, dragRange[1]), dragRange[0]);
@@ -367,7 +375,7 @@
         var el = this.$el;
         var items = el.querySelectorAll('.picker-item');
         [].forEach.call(items, (item, index) => {
-          translateUtil.translateElement(item, null, ITEM_HEIGHT * index);
+          translateUtil.translateElement(item, null, this.itemHeight * index);
         });
         if (this.rotateEffect) {
           this.planUpdateRotate();

--- a/packages/picker/src/picker.vue
+++ b/packages/picker/src/picker.vue
@@ -2,8 +2,8 @@
   <div class="picker" :class="{ 'picker-3d': rotateEffect }">
     <div class="picker-toolbar" v-if="showToolbar"><slot></slot></div>
     <div class="picker-items">
-      <picker-slot v-for="slot in slots" :valueKey="valueKey" :values="slot.values || []" :text-align="slot.textAlign || 'center'" :visible-item-count="visibleItemCount" :class-name="slot.className" :flex="slot.flex" v-model="values[slot.valueIndex]" :rotate-effect="rotateEffect" :divider="slot.divider" :content="slot.content"></picker-slot>
-      <div class="picker-center-highlight"></div>
+      <picker-slot v-for="slot in slots" :valueKey="valueKey" :values="slot.values || []" :text-align="slot.textAlign || 'center'" :visible-item-count="visibleItemCount" :class-name="slot.className" :flex="slot.flex" v-model="values[slot.valueIndex]" :rotate-effect="rotateEffect" :divider="slot.divider" :content="slot.content" :itemHeight="itemHeight"></picker-slot>
+      <div class="picker-center-highlight" :style="{ height: itemHeight + 'px', marginTop: -itemHeight / 2 + 'px' }"></div>
     </div>
   </div>
 </template>
@@ -27,7 +27,6 @@
   }
 
   .picker-center-highlight {
-    height: 36px;
     box-sizing: border-box;
     position: absolute;
     left: 0;
@@ -86,6 +85,10 @@
       rotateEffect: {
         type: Boolean,
         default: false
+      },
+      itemHeight: {
+        type: Number,
+        default: 36
       }
     },
 


### PR DESCRIPTION
Slot height of Picker (`ITEM_HEIGHT`) has a fixed value. ([picker-slot.vue#L118](https://github.com/ElemeFE/mint-ui/blob/master/packages/picker/src/picker-slot.vue#L118))
I want to customize this value.
So I added it to props.

---
Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow the contributing guide.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.
