### PR TITLE
目前手势斜下滑就会触发move，修改为只有在真正的侧滑时才产生move效果，优化cell-swipe操作体验

### DIFF
--- a/packages/cell-swipe/src/cell-swipe.vue
+++ b/packages/cell-swipe/src/cell-swipe.vue
@@ -130,7 +130,7 @@ export default {
       this.wrap.style.webkitTransform = this.translate3d(offset);
       this.rightWrapElm.style.webkitTransform = this.translate3d(this.rightWidth + offset);
       this.leftWrapElm.style.webkitTransform = this.translate3d(-this.leftWidth + offset);
-      this.swiping = true;
+      offset && (this.swiping = true);
     },
 
     swipeLeaveTransition(direction) {


### PR DESCRIPTION
在cell swipe list 的视图下更加明显，用户在尝试滚动列表时手势稍有侧滑就会触发swipe，严重影响用户真实意图的操作体验，修改后，只有用户完全侧滑时才会弹出swipe，在滚动列表时不会弹swipe，符合用户真实意图行为。
