### PR TITLE
fix lazyload option mistake & make lazyload configable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ import PaletteButton from '../packages/palette-button';
 import '../src/assets/font/iconfont.css';
 
 const version = '2.2.3';
-const install = function(Vue) {
+const install = function(Vue, config = {}) {
   if (install.installed) return;
 
   Vue.component(Header.name, Header);
@@ -68,7 +68,8 @@ const install = function(Vue) {
   Vue.use(InfiniteScroll);
   Vue.use(Lazyload, {
     loading: require('./assets/loading-spin.svg'),
-    try: 3
+    attempt: 3,
+    ...config.lazyload
   });
 
   Vue.$messagebox = Vue.prototype.$messagebox = MessageBox;


### PR DESCRIPTION
Solved two problems: 
1. vue-lazyload changed its `options` since 1.0.x ([vue-lazyload document](https://github.com/hilongjw/vue-lazyload#constructor-options))
2. I want to make lazyload configurable globally.

Fixed #457

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow the contributing guide.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.
