### PR TITLE
修复range组件bug

### DIFF
--- a/packages/range/src/index.vue
+++ b/packages/range/src/index.vue
@@ -122,27 +122,29 @@
       const getThumbPosition = () => {
         const contentBox = content.getBoundingClientRect();
         const thumbBox = thumb.getBoundingClientRect();
-
         return {
           left: thumbBox.left - contentBox.left,
-          top: thumbBox.top - contentBox.top
+          top: thumbBox.top - contentBox.top,
+          thumbBoxLeft: thumbBox.left
         };
       };
 
       let dragState = {};
       draggable(thumb, {
-        start: () => {
+        start: (event) => {
           if (this.disabled) return;
           const position = getThumbPosition();
+          const thumbClickDetalX = event.clientX - position.thumbBoxLeft;
           dragState = {
             thumbStartLeft: position.left,
-            thumbStartTop: position.top
+            thumbStartTop: position.top,
+            thumbClickDetalX: thumbClickDetalX
           };
         },
         drag: (event) => {
           if (this.disabled) return;
           const contentBox = content.getBoundingClientRect();
-          const deltaX = event.pageX - contentBox.left - dragState.thumbStartLeft;
+          const deltaX = event.pageX - contentBox.left - dragState.thumbStartLeft - dragState.thumbClickDetalX;
           const stepCount = Math.ceil((this.max - this.min) / this.step);
           const newPosition = (dragState.thumbStartLeft + deltaX) - (dragState.thumbStartLeft + deltaX) % (contentBox.width / stepCount);
 


### PR DESCRIPTION
修复range组件在点击开始的时候（点击位置不在按钮的最左边），向右/向左移动一点时候，按钮会跳动的问题。