### PR TITLE
cell组件，传入vue-route具名路径时没有拦截click事件，导致跳转不正确

### DIFF
--- a/packages/cell/src/cell.vue
+++ b/packages/cell/src/cell.vue
@@ -1,5 +1,5 @@
 <template>
-  <a class="mint-cell" :href="href">
+  <a class="mint-cell" :href="href" @click="handleClick($event)">
     <span class="mint-cell-mask" v-if="isLink"></span>
     <div class="mint-cell-left">
       <slot name="left"></slot>


### PR DESCRIPTION
在a里面增加了点击事件用于捕获a标签的点击事件，否则无法让router push