### PR TITLE
修复pull-down示例中下拉的异常

### DIFF
--- a/example/pages/pull-down.vue
+++ b/example/pages/pull-down.vue
@@ -7,7 +7,7 @@
     <div class="loading-background" :style="{ transform: 'scale3d(' + moveTranslate + ',' + moveTranslate + ',1)' }">
       translateScale : {{ moveTranslate }} 
     </div>
-    <div class="page-loadmore-wrapper" ref="wrapper" >
+    <div class="page-loadmore-wrapper" ref="wrapper" :style="{ height: wrapperHeight + 'px' }">
       <mt-loadmore :top-method="loadTop" @translate-change="translateChange" @top-status-change="handleTopChange" ref="loadmore">
         <ul class="page-loadmore-list">
           <li v-for="item in list" class="page-loadmore-listitem">{{ item }}</li>


### PR DESCRIPTION
issue #928 中提到的下拉异常，是由于pull-down示例中wrapper的高度未固定而产生的。