### PR TITLE
fix the unexpected behavior of Loamore's autoFill

### DIFF
--- a/packages/loadmore/src/loadmore.vue
+++ b/packages/loadmore/src/loadmore.vue
@@ -136,7 +136,8 @@
         startScrollTop: 0,
         currentY: 0,
         topStatus: '',
-        bottomStatus: ''
+        bottomStatus: '',
+        isAutoFill: false
       };
     },
 
@@ -178,18 +179,27 @@
         setTimeout(() => {
           this.topStatus = 'pull';
         }, 200);
+        this.$nextTick(() => {
+          this.checkContainerFilled();
+          if (!this.bottomAllLoaded && !this.containerFilled) {
+            this.fillContainer();
+          }
+        });
       },
 
       onBottomLoaded() {
         this.bottomStatus = 'pull';
         this.bottomDropped = false;
         this.$nextTick(() => {
-          if (this.scrollEventTarget === window) {
-            document.body.scrollTop += 50;
-          } else {
-            this.scrollEventTarget.scrollTop += 50;
+          if (!this.isAutoFill) {
+            if (this.scrollEventTarget === window) {
+              document.body.scrollTop += 50;
+            } else {
+              this.scrollEventTarget.scrollTop += 50;
+            }
           }
           this.translate = 0;
+          this.isAutoFill = false;
         });
         if (!this.bottomAllLoaded && !this.containerFilled) {
           this.fillContainer();
@@ -237,17 +247,22 @@
         }
       },
 
+      checkContainerFilled() {
+        if (this.scrollEventTarget === window) {
+          this.containerFilled = this.$el.getBoundingClientRect().bottom >=
+            document.documentElement.getBoundingClientRect().bottom;
+        } else {
+          this.containerFilled = this.$el.getBoundingClientRect().bottom >=
+            this.scrollEventTarget.getBoundingClientRect().bottom;
+        }
+      },
+
       fillContainer() {
         if (this.autoFill) {
           this.$nextTick(() => {
-            if (this.scrollEventTarget === window) {
-              this.containerFilled = this.$el.getBoundingClientRect().bottom >=
-                document.documentElement.getBoundingClientRect().bottom;
-            } else {
-              this.containerFilled = this.$el.getBoundingClientRect().bottom >=
-                this.scrollEventTarget.getBoundingClientRect().bottom;
-            }
+            this.checkContainerFilled();
             if (!this.containerFilled) {
+              this.isAutoFill = true;
               this.bottomStatus = 'loading';
               this.bottomMethod();
             }


### PR DESCRIPTION
1. 解决触发autoFill时，在onBottomLoaded会触发50px的位移，导致首行内容移出可见区域的问题。
2. 根据官方文档，topMethod用于下拉刷新。解决下拉刷新后若列表未充满不会触发autoFill的问题。
---
1. fix the unexpected 50px scroll while autoFilling. 
2. topMethod will also trigger autoFill when the container is not filled after topMethod loaded.

* [x] Make sure you follow the contributing guide.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.
