### PR TITLE
fix index-list scroll bug in ios-wx

### DIFF
--- a/lib/style.css
+++ b/lib/style.css
@@ -1842,7 +1842,9 @@ display: inline-block;
 .mint-indexlist-content {
     margin: 0;
     padding: 0;
-    overflow: auto
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+    overflow-scrolling: touch
 }
 .mint-indexlist-nav {
     position: absolute;


### PR DESCRIPTION
index-list组件在ios微信浏览器中无法自由滑动, 只能手指按住缓慢拖动, 没有物理加速度效果
而在安卓的微信浏览器和其他主流浏览器内均没有这个问题
官方文档的例子中也没能体现这个问题
故修复此bug
