### PR TITLE
fix: when 'closeOnClickModal' option is set to MessageBox, 'doClose()' is triggered twice

### DIFF
--- a/packages/message-box/src/message-box.vue
+++ b/packages/message-box/src/message-box.vue
@@ -196,6 +196,8 @@
 
     methods: {
       doClose() {
+        if (!this.opened) return;
+
         this.value = false;
         this._closing = true;
 


### PR DESCRIPTION
**[Bugfix]** when 'closeOnClickModal' option is set 'true' to MessageBox, click on the modal background, and then 'doClose()' of MessageBox is triggered twice.

The reason is that 'closeOnClickModal' will trigger 'doClose()' directly, but the MessageBox's value is changed in 'doClose()', then the changed value which has been watched by Popup will trigger 'close' again.

I just added one line code at the beginning of MessageBox's 'doClose' function, but adding a same condition to the 'watch' callback of 'value' in Popup is another way. I'm not sure which is better, but considering the former approach's affection is less.