### PR TITLE
fix:修正picker组件设置defaultIndex无效的问题

### DIFF
--- a/packages/picker/src/picker.vue
+++ b/packages/picker/src/picker.vue
@@ -95,7 +95,8 @@
     created() {
       this.$on('slotValueChange', this.slotValueChange);
       var slots = this.slots || [];
-      var values = [];
+      this.values = [];
+      var values = this.values;
       var valueIndexCount = 0;
       slots.forEach(slot => {
         if (!slot.divider) {
@@ -170,14 +171,26 @@
     },
 
     computed: {
-      values() {
-        var slots = this.slots || [];
-        var values = [];
-        slots.forEach(function(slot) {
-          if (!slot.divider) values.push(slot.value);
-        });
+      values: {
+        get() {
+          var slots = this.slots || [];
+          var values = [];
+          slots.forEach(function(slot) {
+            if (!slot.divider) values.push(slot.value);
+          });
 
-        return values;
+          return values;
+        },
+        set(values) {
+          var slots = this.slots || [];
+          var valueIndexCount = 0;
+          slots.forEach(function(slot) {
+            if (!slot.divider) {
+              slots.value = values[valueIndexCount];
+              valueIndexCount = valueIndexCount + 1;
+            }
+          });
+        }
       },
       slotCount() {
         var slots = this.slots || [];


### PR DESCRIPTION
fix #1088 
fix #1059 

导致这两个问题的原因是传参错误。 created 钩子里使用局部变量values来存储默认值，而  `this.slotValueChange()` 中触发change 事件时，传的参数是`this.values`，

观察提交记录，此问题在2.7.8([link](https://github.com/ElemeFE/mint-ui/compare/629836f488e7a6f08b8e8f48dd6f490b3823b109...c696c4e90247697726d6b08b183254f116440537#diff-8260388fd5ae7e8651816416bc8e7b8cR102)) 中引入。
