### PR TITLE
support fullPath for mt-cell.vue

### DIFF
--- a/packages/cell/src/cell.vue
+++ b/packages/cell/src/cell.vue
@@ -74,7 +74,7 @@ export default {
           this.added = true;
           this.$el.addEventListener('click', this.handleClick);
         });
-        return resolved.path;
+        return resolved.fullPath || resolved.path;
       }
       return this.to;
     }


### PR DESCRIPTION
Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow the contributing guide.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

---

there are both `fullPath` and `path` in vue-router's instance(e.g. `this.$route` in vue component), the previous one contains questring/hash information in route and the last one doesn't. Sometimes you don't want to switch to another route but just change the querystring/hash for current route. mt-cell pass resolved route's `path` property as computed data 'href', which provided to the wrapper element `<a :href="href">` without the querystring/hash.

To support that, select resolved matched `$route`'s `fullPath` as `href` and get `path` as fallback value.