### PR TITLE
增加上下文判断

### DIFF
--- a/packages/toast/src/toast.js
+++ b/packages/toast/src/toast.js
@@ -44,7 +44,8 @@ let Toast = (options = {}) => {
   instance.className = options.className || '';
   instance.iconClass = options.iconClass || '';
 
-  document.body.appendChild(instance.$el);
+  let parentEle = options.context || document.body;
+  parentEle.appendChild(instance.$el);
   Vue.nextTick(function() {
     instance.visible = true;
     instance.$el.removeEventListener('transitionend', removeDom);


### PR DESCRIPTION
在使用过程中发现直接使用document.body在某些场景下会导致toast永远悬浮在最上层。与实际想要实现效果不符。建议增加上下文判定。下面为调用示例：
```
Toast({
                  message: `已更新${data.data.list.length}条动态`,
                  position: 'top',
                  duration: 1000,
                  context: this.$el
                });
```

Please makes sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow the contributing guide.
* [ ] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.
