### PR TITLE
修复Loadmore的transform样式导致的Popup定位错误

### DIFF
--- a/packages/loadmore/src/loadmore.vue
+++ b/packages/loadmore/src/loadmore.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="mint-loadmore">
-    <div class="mint-loadmore-content" :class="{ 'is-dropped': topDropped || bottomDropped}" :style="{ 'transform': 'translate3d(0, ' + translate + 'px, 0)' }">
+    <div class="mint-loadmore-content" :class="{ 'is-dropped': topDropped || bottomDropped}" :style="{ 'transform': transform }">
       <slot name="top">
         <div class="mint-loadmore-top" v-if="topMethod">
           <spinner v-if="topStatus === 'loading'" class="mint-loadmore-spinner" :size="20" type="fading-circle"></spinner>
@@ -138,6 +138,12 @@
         topStatus: '',
         bottomStatus: ''
       };
+    },
+
+    computed: {
+      transform() {
+        return this.translate === 0 ? null : 'translate3d(0, ' + this.translate + 'px, 0)';
+      }
     },
 
     watch: {


### PR DESCRIPTION
https://github.com/ElemeFE/mint-ui/issues/1052

当Loadmore的transform样式存在时，子组件Popup会以Loadmore为基准定位，所以当translate为0时，去掉transform样式，让Popup可以正常定位。