### PR TITLE
[bug] fixed 没有关闭messagebox 的情况下再打开一次messagebox 有bug

### DIFF
--- a/packages/message-box/src/message-box.js
+++ b/packages/message-box/src/message-box.js
@@ -76,6 +76,7 @@ const defaultCallback = action => {
         currentMsg.resolve(action);
       }
     }
+    showNextMsg();
   }
 };
 
@@ -112,9 +113,7 @@ var showNextMsg = function() {
       });
       document.body.appendChild(instance.$el);
 
-      Vue.nextTick(() => {
-        instance.value = true;
-      });
+      instance.value = true;
     }
   }
 };


### PR DESCRIPTION
"version": "2.2.13"  
jsfiddle demo：https://jsfiddle.net/tjjmj3r1/22/

分两种情况，一种是马上打开，后者内容会覆盖前者；
第一种情况：
```
MessageBox.alert('操作成功!', '提示');
MessageBox.alert(第二次!', '提示');
// 只会显示“第二次!”，，“操作成功” 被直接覆盖
```
第二种是过一段时间后再打开，后者不会马上显示，而是等messagebox 关闭后再开的时候显示，导致信息不对
```
// 执行弹窗
MessageBox.alert('操作成功!', '提示');
setTimeout(() => {        
    MessageBox.alert('第二次!', '提示');
}, 1000);
// 只会显示“操作成功!”，，“第二次!” 现在不会显示
// 点击空白处关闭弹窗
// 第二次执行弹窗
MessageBox.alert('哇哈哈', '提示'); // “第二次!” 被推迟到现在才显示，，“哇哈哈” 会被推迟到下一次弹窗才显示
```

增加 line79 后，保留多次的message 可以依次出现
删除 line115 后，可以保留alert 的推列出现而不后者覆盖前者，也不再导致message 内容推迟出现



Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow the contributing guide.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.
