### PR TITLE
loadmore组件的translate计算的Bug

### DIFF
--- a/packages/loadmore/src/loadmore.vue
+++ b/packages/loadmore/src/loadmore.vue
@@ -291,16 +291,16 @@
           return;
         }
         this.currentY = event.touches[0].clientY;
-        let distance = (this.currentY - this.startY) / this.distanceIndex;
+        let distance = this.currentY - this.startY;
         this.direction = distance > 0 ? 'down' : 'up';
         if (typeof this.topMethod === 'function' && this.direction === 'down' &&
           this.getScrollTop(this.scrollEventTarget) === 0 && this.topStatus !== 'loading') {
           event.preventDefault();
           event.stopPropagation();
           if (this.maxDistance > 0) {
-            this.translate = distance <= this.maxDistance ? distance - this.startScrollTop : this.translate;
+            this.translate = distance <= this.maxDistance ? (distance - this.startScrollTop) / this.distanceIndex : this.translate;
           } else {
-            this.translate = distance - this.startScrollTop;
+            this.translate = (distance - this.startScrollTop) / this.distanceIndex;
           }
           if (this.translate < 0) {
             this.translate = 0;
@@ -317,9 +317,9 @@
           event.stopPropagation();
           if (this.maxDistance > 0) {
             this.translate = Math.abs(distance) <= this.maxDistance
-              ? this.getScrollTop(this.scrollEventTarget) - this.startScrollTop + distance : this.translate;
+              ? (this.getScrollTop(this.scrollEventTarget) - this.startScrollTop + distance ) / this.distanceIndex: this.translate;
           } else {
-            this.translate = this.getScrollTop(this.scrollEventTarget) - this.startScrollTop + distance;
+            this.translate = (this.getScrollTop(this.scrollEventTarget) - this.startScrollTop + distance) / this.distanceIndex;
           }
           if (this.translate > 0) {
             this.translate = 0;

--- a/packages/tab-container/src/tab-container.vue
+++ b/packages/tab-container/src/tab-container.vue
@@ -3,8 +3,6 @@
     @touchstart="startDrag"
     @mousedown="startDrag"
     @touchmove="onDrag"
-    @mousemove="onDrag"
-    @mouseup="endDrag"
     @touchend="endDrag"
     class="mint-tab-container">
     <div
@@ -33,7 +31,7 @@
 </style>
 
 <script>
-import { once } from 'mint-ui/src/utils/dom';
+import { once,on,off } from 'mint-ui/src/utils/dom';
 import arrayFindIndex from 'array-find-index';
 
 /**
@@ -90,6 +88,11 @@ export default {
     this.limitWidth = this.pageWidth / 4;
   },
 
+  destroyed() {
+    off(document.documentElement,'mousemove',this.onDrag);
+    off(document.documentElement,'mouseup',this.endDrag);
+  },
+
   methods: {
     swipeLeaveTransition(lastIndex = 0) {
       if (typeof this.index !== 'number') {
@@ -122,6 +125,10 @@ export default {
       this.dragging = true;
       this.start.x = evt.pageX;
       this.start.y = evt.pageY;
+      if (!evt.changedTouches) {
+        on(document.documentElement,'mousemove',this.onDrag);
+        once(document.documentElement,'mouseup',this.endDrag);
+      }
     },
 
     onDrag(evt) {
@@ -155,7 +162,7 @@ export default {
       this.swipeMove(offset);
     },
 
-    endDrag() {
+    endDrag(evt) {
       if (!this.swiping) return;
       this.dragging = false;
       const direction = this.offsetLeft > 0 ? -1 : 1;
@@ -171,6 +178,9 @@ export default {
       }
 
       this.swipeLeaveTransition();
+      if (!evt.changedTouches) {
+        off(document.documentElement,'mousemove',this.onDrag);
+      }
     }
   }
 };


### PR DESCRIPTION
loadmore组件 translate的计算，应该是手指移动的距离distance 先和 scrollTop进行运算后的值再和手指移动与组件移动距离的比值distanceIndex相除；而不是distance 先除以distanceIndex，再和scrollTop作运算，此做法会导致，当loadmore组件已经下拉或者上拉了一段距离后，再通过手指直接上拉或者下拉到达顶部或者底部的时候，translate并没有变化 ，需要继续拉动一段距离translate才会变化.
tab-container组件的mouse事件处理，建议不要直接在组件上绑定mousemove和mouseup，因为可能在滑动的时候，松开鼠标的时候，鼠标已经不再组件上方了，然后鼠标移动回组件里面的时候，组件会跟着鼠标滑动。所以建议把mousemove和mouseup绑定到document.documentElement对象上，并且是在组件的mousedown数据触发时才绑定，mouseup事件触发时或者组件destroyed钩子触发的时候就解除绑定