### PR TITLE
fix 点击滑动时 浏览器闪烁

### DIFF
--- a/packages/tab-container-item/src/tab-container-item.vue
+++ b/packages/tab-container-item/src/tab-container-item.vue
@@ -1,6 +1,5 @@
 <template>
   <div
-    v-show="$parent.swiping || id === $parent.currentActive"
     class="mint-tab-container-item">
     <slot></slot>
   </div>

--- a/packages/tab-container/src/tab-container.vue
+++ b/packages/tab-container/src/tab-container.vue
@@ -104,7 +104,6 @@ export default {
 
         once(this.wrap, 'webkitTransitionEnd', _ => {
           this.wrap.classList.remove('swipe-transition');
-          this.wrap.style.webkitTransform = '';
           this.swiping = false;
           this.index = null;
         });


### PR DESCRIPTION
修复原有隐藏item项，并在滑动时重新计算偏移，导致的浏览器闪烁