### PR TITLE
[完善popup组建] 当popup嵌套时，关闭modal层级错乱问题

### DIFF
--- a/src/utils/popup/popup-manager.js
+++ b/src/utils/popup/popup-manager.js
@@ -26,6 +26,22 @@ const getModal = function() {
   return modalDom;
 };
 
+/**
+ * 判断modalDom 是否是再其他 popup中嵌套，如果是嵌套则将modal 移动到最外层modal的父节点下面
+ * @param {最后一次生成的modalDom} modalDom 
+ */
+const ifIsNested = function(modalDom) {
+  if (modalDom) {
+    if (modalDom.parentNode && modalDom.parentNode !== document.body) {
+      if (modalDom.parentNode.parentNode && modalDom.parentNode.parentNode.className && modalDom.parentNode.parentNode.className.indexOf('mint-popup') !== -1) {
+        modalDom.parentNode.parentNode.parentNode.appendChild(modalDom)
+      }  else {
+        isNested(modalDom.parentNode)
+      }
+    }
+  }
+}
+
 const instances = {};
 
 const PopupManager = {

--- a/src/utils/popup/popup-manager.js
+++ b/src/utils/popup/popup-manager.js
@@ -149,6 +149,8 @@ const PopupManager = {
         }
       }
     }
+    
+    ifIsNested(modalDom)
 
     if (modalStack.length === 0) {
       if (this.modalFade) {


### PR DESCRIPTION
Please makes sure these boxes are checked before submitting your PR, thank you!

发现 [类popup] 组件不支持嵌套，如果嵌套则会再关闭内层的popup组建时候 不能正确的关闭modal遮罩层

举个栗子：

再 popup内部有一个dateTime picker 组建，当我们展开关闭dateTime picker组建时候遮罩位置仍然会盖住原来的页面

解决方案：

再关闭modal的时候 判断其是否是被嵌套，如果是则将modal 通过appendChild 到最外层的parentNote下面

* [ ] Make sure you follow the contributing guide.
* [ ] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.
