### PR TITLE
Loadmore throw error with cancelable=false

### DIFF
--- a/packages/loadmore/src/loadmore.vue
+++ b/packages/loadmore/src/loadmore.vue
@@ -295,7 +295,9 @@
         this.direction = distance > 0 ? 'down' : 'up';
         if (typeof this.topMethod === 'function' && this.direction === 'down' &&
           this.getScrollTop(this.scrollEventTarget) === 0 && this.topStatus !== 'loading') {
-          event.preventDefault();
+          if (event.cancelable) {
+            event.preventDefault();
+          }
           event.stopPropagation();
           if (this.maxDistance > 0) {
             this.translate = distance <= this.maxDistance ? distance - this.startScrollTop : this.translate;
@@ -313,7 +315,9 @@
         }
         if (typeof this.bottomMethod === 'function' && this.direction === 'up' &&
           this.bottomReached && this.bottomStatus !== 'loading' && !this.bottomAllLoaded) {
-          event.preventDefault();
+          if (event.cancelable) {
+            event.preventDefault();
+          }
           event.stopPropagation();
           if (this.maxDistance > 0) {
             this.translate = Math.abs(distance) <= this.maxDistance


### PR DESCRIPTION
When use both :top-method and :bottom-method in loadmore.vue. Touchmove event handler function 'handleTouchMove()' throw error.
Ignored attempt to cancel a touchmove event with cancelable=false.
Fix it with event.cancelable.
