### PR TITLE
fixed: 解决tab-container在tab页较长时，纵向页面移动与横向tab切换容易造成页面错乱的问题。

### DIFF
--- a/example/pages/tab-container.vue
+++ b/example/pages/tab-container.vue
@@ -8,13 +8,13 @@
     <div class="page-tab-container">
       <mt-tab-container class="page-tabbar-tab-container" v-model="active" swipeable>
         <mt-tab-container-item id="tab-container1">
-          <mt-cell v-for="n in 10" title="tab-container 1"></mt-cell>
+          <mt-cell v-for="n in 100" :key="n" title="tab-container 1"></mt-cell>
         </mt-tab-container-item>
         <mt-tab-container-item id="tab-container2">
-          <mt-cell v-for="n in 5" title="tab-container 2"></mt-cell>
+          <mt-cell v-for="n in 5" :key="n" title="tab-container 2"></mt-cell>
         </mt-tab-container-item>
         <mt-tab-container-item id="tab-container3">
-          <mt-cell v-for="n in 7" title="tab-container 3"></mt-cell>
+          <mt-cell v-for="n in 7" :key="n" title="tab-container 3"></mt-cell>
         </mt-tab-container-item>
       </mt-tab-container>
     </div>

--- a/packages/tab-container/src/tab-container.vue
+++ b/packages/tab-container/src/tab-container.vue
@@ -62,6 +62,7 @@ export default {
     return {
       start: { x: 0, y: 0 },
       swiping: false,
+      verSwipingDuringDragging: false, // vertical swiping
       activeItems: [],
       pageWidth: 0,
       currentActive: this.value
@@ -126,6 +127,7 @@ export default {
 
     onDrag(evt) {
       if (!this.dragging) return;
+      if (this.verSwipingDuringDragging) return;
       let swiping;
       const e = evt.changedTouches ? evt.changedTouches[0] : evt;
       const offsetTop = e.pageY - this.start.y;
@@ -134,7 +136,10 @@ export default {
       const x = Math.abs(offsetLeft);
 
       swiping = !(x < 5 || (x >= 5 && y >= x * 1.73));
-      if (!swiping) return;
+      if (!swiping) {
+        this.verSwipingDuringDragging = true;
+        return;
+      }
       evt.preventDefault();
 
       const len = this.$children.length - 1;
@@ -156,6 +161,7 @@ export default {
     },
 
     endDrag() {
+      this.verSwipingDuringDragging = false;
       if (!this.swiping) return;
       this.dragging = false;
       const direction = this.offsetLeft > 0 ? -1 : 1;


### PR DESCRIPTION
fixed: 解决tab-container在tab页较长时，纵向页面移动与横向tab切换容易造成页面错乱的问题。解决方式，对onDrag做一定限制，比较好的解决了此问题。

update: 更新tab-container demo

Please makes sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow the contributing guide.
* [ ] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.
