### PR TITLE
fixed:loadmore 目标滚动dom元素不一定需要overflowY

### DIFF
--- a/packages/loadmore/src/loadmore.vue
+++ b/packages/loadmore/src/loadmore.vue
@@ -204,14 +204,10 @@
 
       getScrollEventTarget(element) {
         let currentNode = element;
-        while (currentNode && currentNode.tagName !== 'HTML' &&
+        if (currentNode && currentNode.tagName !== 'HTML' &&
           currentNode.tagName !== 'BODY' && currentNode.nodeType === 1) {
-          let overflowY = document.defaultView.getComputedStyle(currentNode).overflowY;
-          if (overflowY === 'scroll' || overflowY === 'auto') {
             return currentNode;
           }
-          currentNode = currentNode.parentNode;
-        }
         return window;
       },
 


### PR DESCRIPTION
目标滚动dom元素的样式不一定需要overflowY才能下拉刷新