### PR TITLE
fix: position

### DIFF
--- a/packages/popup/src/popup.vue
+++ b/packages/popup/src/popup.vue
@@ -135,7 +135,7 @@
     },
 
     beforeMount() {
-      if (this.popupTransition !== 'popup-fade') {
+      if (this.popupTransition !== 'popup-fade' && this.position) {
         this.currentTransition = `popup-slide-${ this.position }`;
       }
     },


### PR DESCRIPTION
比如想用popup做从中间bounce-in跳出的弹窗，则可设置popupTransition为popup-bounce等自定义
```css
.popup-bounce-enter-active {
    animation: popup-bounce-in .5s;
  }
  .popup-bounce-leave-active {
    animation: popup-bounce-in .5s reverse;
  }
  @keyframes popup-bounce-in {
    0% {
      transform: translate3d(-50%, -50%, 0) scale(0);
    }
    50% {
      transform: translate3d(-50%, -50%, 0) scale(1.2);
    }
    100% {
      transform: translate3d(-50%, -50%, 0) scale(1);
    }
  }
```
